### PR TITLE
fix(ui): resolve display issues with Tailwind color classes (Vibe Kanban)

### DIFF
--- a/app/tailwind.config.ts
+++ b/app/tailwind.config.ts
@@ -9,6 +9,7 @@ export default {
     extend: {
       colors: {
         primary: {
+          DEFAULT: '#0d9488', // Brand color
           50: '#f0fdfa',
           100: '#ccfbf1',
           200: '#99f6e4',
@@ -22,6 +23,7 @@ export default {
           950: '#042f2e',
         },
         secondary: {
+          DEFAULT: '#0f172a', // Deep slate
           50: '#f8fafc',
           100: '#f1f5f9',
           200: '#e2e8f0',
@@ -31,7 +33,7 @@ export default {
           600: '#475569',
           700: '#334155',
           800: '#1e293b',
-          900: '#0f172a', // Deep slate
+          900: '#0f172a',
           950: '#020617',
         },
         accent: {
@@ -48,7 +50,7 @@ export default {
           900: '#881337',
         },
         success: {
-          DEFAULT: '#10b981', // emerald-500
+          DEFAULT: '#10b981',
           50: '#ecfdf5',
           100: '#d1fae5',
           200: '#a7f3d0',
@@ -73,14 +75,14 @@ export default {
           800: '#92400e',
           900: '#78350f',
         },
-        border: 'hsl(var(--color-border))',
-        background: 'hsl(var(--color-background))',
-        foreground: 'hsl(var(--color-foreground))',
+        border: 'rgb(var(--color-border) / <alpha-value>)',
+        background: 'rgb(var(--color-background) / <alpha-value>)',
+        foreground: 'rgb(var(--color-foreground) / <alpha-value>)',
         muted: {
-          DEFAULT: 'hsl(var(--color-muted))',
-          foreground: 'hsl(var(--color-muted-foreground))',
+          DEFAULT: 'rgb(var(--color-muted) / <alpha-value>)',
+          foreground: 'rgb(var(--color-muted-foreground) / <alpha-value>)',
         },
-        ring: 'hsl(var(--color-ring))',
+        ring: 'rgb(var(--color-ring) / <alpha-value>)',
       },
       fontFamily: {
         sans: [


### PR DESCRIPTION
## Summary

Fixes display issues on the site including oversized icons and broken color utilities caused by Tailwind CSS configuration problems.

## Changes Made

### 1. Fixed CSS Variables Format Mismatch
- Changed `hsl(var(--color-...))` to `rgb(var(--color-...) / <alpha-value>)` for:
  - `border`, `background`, `foreground`
  - `muted` (both DEFAULT and foreground)
  - `ring`

This resolves the mismatch between how CSS variables are defined in `globals.css` (space-separated RGB values like `--color-primary: 13 148 136`) and how they were being consumed by Tailwind.

### 2. Added DEFAULT Color Values
- Added `DEFAULT: '#0d9488'` for the `primary` color palette
- Added `DEFAULT: '#0f172a'` for the `secondary` color palette

This enables utility classes like:
- `text-primary` / `text-secondary`
- `bg-primary/10` / `bg-secondary/10`
- `text-success` / `bg-success/10`

## Root Cause

The display issues were caused by:
1. **Format mismatch**: CSS variables defined as RGB but used with `hsl()` function
2. **Missing DEFAULT values**: Tailwind requires explicit DEFAULT values to use color names without shades (e.g., `text-primary` requires a DEFAULT value in the primary palette)

## Impact

These fixes ensure all Tailwind color utilities resolve correctly throughout the application, preventing visual bugs like:
- Oversized or giant icons
- Missing or incorrect colors on badges, buttons, and text
- Broken opacity modifiers (`/10`, `/20`, etc.)

---

This PR was written using [Vibe Kanban](https://vibekanban.com)