### PR TITLE
fix(deployment): update build commands for Vercel root directory

### DIFF
--- a/vercel.json
+++ b/vercel.json
@@ -1,7 +1,7 @@
 {
-  "buildCommand": "cd app && npm run build",
-  "outputDirectory": "app/.next",
-  "installCommand": "cd app && npm ci",
+  "buildCommand": "npm run build",
+  "outputDirectory": ".next",
+  "installCommand": "npm ci",
   "framework": "nextjs",
 
   "headers": [


### PR DESCRIPTION
## Problem
Deployment failing with "Command 'cd app && npm ci' exited with 1" error.

## Root Cause
Since Vercel Root Directory is set to 'app', the commands already run from
within the app directory. The `cd app &&` prefix is trying to change to
a subdirectory that doesn't exist from the current working directory.

## Solution
Remove `cd app &&` prefixes from build/install commands since we're already
in the app directory. Also update outputDirectory path.

## Changes
- `installCommand`: `cd app && npm ci` → `npm ci`
- `buildCommand`: `cd app && npm run build` → `npm run build`
- `outputDirectory`: `app/.next` → `.next`

## Testing
This fixes the deployment error by correctly referencing paths relative
to the Vercel Root Directory setting.

Refs: AMP-999