### PR TITLE
fix(r2): lazy-load environment variables to prevent build-time errors

### DIFF
--- a/app/src/app/api/episodes/[id]/route.ts
+++ b/app/src/app/api/episodes/[id]/route.ts
@@ -1,6 +1,6 @@
 import { NextResponse } from 'next/server';
 import { createClient } from '@/lib/supabase/server';
-import { deleteFromR2, R2_EPISODES_CUSTOM_DOMAIN } from '@/lib/r2';
+import { deleteFromR2, getR2EpisodesCustomDomain } from '@/lib/r2';
 
 /**
  * Verifies that the user owns the episode via its podcast.
@@ -147,8 +147,9 @@ export async function DELETE(
     if (episode.audio_url) {
       try {
         // Extract the R2 key from the URL
-        if (R2_EPISODES_CUSTOM_DOMAIN && episode.audio_url.startsWith(R2_EPISODES_CUSTOM_DOMAIN)) {
-          const key = episode.audio_url.replace(R2_EPISODES_CUSTOM_DOMAIN, '').replace(/^\//, '');
+        const r2CustomDomain = getR2EpisodesCustomDomain();
+        if (r2CustomDomain && episode.audio_url.startsWith(r2CustomDomain)) {
+          const key = episode.audio_url.replace(r2CustomDomain, '').replace(/^\//, '');
           await deleteFromR2(key);
         }
       } catch (r2Error) {

--- a/app/src/app/podcasts/[id]/episodes/new/page.tsx
+++ b/app/src/app/podcasts/[id]/episodes/new/page.tsx
@@ -1,7 +1,7 @@
 import { redirect } from 'next/navigation';
 import Link from 'next/link';
 import { createClient } from '@/lib/supabase/server';
-import { uploadToR2, isValidAudioFile, isValidFileSize, R2_EPISODES_CUSTOM_DOMAIN } from '@/lib/r2';
+import { uploadToR2, isValidAudioFile, isValidFileSize, getR2EpisodesCustomDomain } from '@/lib/r2';
 import { SimpleUploadForm } from '@/components/simple-upload-form';
 
 export const dynamic = 'force-dynamic';
@@ -98,8 +98,8 @@ async function uploadEpisode(podcastId: string, formData: FormData) {
     // If database insert fails, try to clean up the uploaded file
     try {
       const { deleteFromR2 } = await import('@/lib/r2');
-      if (audioUrl.startsWith(R2_EPISODES_CUSTOM_DOMAIN)) {
-        const key = audioUrl.replace(R2_EPISODES_CUSTOM_DOMAIN, '').replace(/^\//, '');
+      if (audioUrl.startsWith(getR2EpisodesCustomDomain())) {
+        const key = audioUrl.replace(getR2EpisodesCustomDomain(), '').replace(/^\//, '');
         await deleteFromR2(key);
       }
     } catch (cleanupError) {

--- a/app/src/lib/r2.ts
+++ b/app/src/lib/r2.ts
@@ -16,26 +16,29 @@ const getRequiredEnv = (name: string): string => {
   return value.trim();
 };
 
-// R2 Configuration
-export const R2_CONFIG = {
-  accountId: getRequiredEnv('R2_ACCOUNT_ID'),
-  accessKeyId: getRequiredEnv('R2_ACCESS_KEY_ID'),
-  secretAccessKey: getRequiredEnv('R2_SECRET_ACCESS_KEY'),
-  bucketName: getRequiredEnv('R2_EPISODES_BUCKET'),
-  publicUrl: getRequiredEnv('R2_EPISODES_CUSTOM_DOMAIN'),
-} as const;
+// R2 Configuration (lazy-loaded to avoid build-time errors)
+function getR2Config() {
+  return {
+    accountId: getRequiredEnv('R2_ACCOUNT_ID'),
+    accessKeyId: getRequiredEnv('R2_ACCESS_KEY_ID'),
+    secretAccessKey: getRequiredEnv('R2_SECRET_ACCESS_KEY'),
+    bucketName: getRequiredEnv('R2_EPISODES_BUCKET'),
+    publicUrl: getRequiredEnv('R2_EPISODES_CUSTOM_DOMAIN'),
+  } as const;
+}
 
 // R2 Client (singleton)
 let r2Client: S3Client | null = null;
 
 function getR2Client(): S3Client {
   if (!r2Client) {
+    const config = getR2Config();
     r2Client = new S3Client({
       region: 'auto',
-      endpoint: `https://${R2_CONFIG.accountId}.r2.cloudflarestorage.com`,
+      endpoint: `https://${config.accountId}.r2.cloudflarestorage.com`,
       credentials: {
-        accessKeyId: R2_CONFIG.accessKeyId,
-        secretAccessKey: R2_CONFIG.secretAccessKey,
+        accessKeyId: config.accessKeyId,
+        secretAccessKey: config.secretAccessKey,
       },
     });
   }
@@ -93,8 +96,9 @@ export async function uploadToR2(
   }
 
   try {
+    const config = getR2Config();
     const command = new PutObjectCommand({
-      Bucket: R2_CONFIG.bucketName,
+      Bucket: config.bucketName,
       Key: key,
       Body: body,
       ContentType: contentType,
@@ -103,7 +107,7 @@ export async function uploadToR2(
     await getR2Client().send(command);
 
     // Return public URL
-    return `${R2_CONFIG.publicUrl}/${key}`;
+    return `${config.publicUrl}/${key}`;
   } catch (error) {
     console.error('R2 upload failed:', error);
     throw new Error(
@@ -120,8 +124,9 @@ export async function uploadToR2(
  */
 export async function deleteFromR2(key: string): Promise<void> {
   try {
+    const config = getR2Config();
     const command = new DeleteObjectCommand({
-      Bucket: R2_CONFIG.bucketName,
+      Bucket: config.bucketName,
       Key: key,
     });
 
@@ -169,6 +174,11 @@ export function isValidFileSize(file: File, maxSizeMB: number = 500): boolean {
   return file.size <= maxSizeBytes;
 }
 
-// Re-export constants for backward compatibility
-export const R2_EPISODES_BUCKET = R2_CONFIG.bucketName;
-export const R2_EPISODES_CUSTOM_DOMAIN = R2_CONFIG.publicUrl;
+// Re-export constants for backward compatibility (lazy-loaded)
+export function getR2EpisodesBucket(): string {
+  return getR2Config().bucketName;
+}
+
+export function getR2EpisodesCustomDomain(): string {
+  return getR2Config().publicUrl;
+}


### PR DESCRIPTION
## Problem
Vercel deployments were failing with:
Error: Missing required environment variable: R2_ACCOUNT_ID

This was happening during the build process when Next.js was collecting page data. The R2 configuration was being initialized at module load time, which meant environment variables were accessed during the build - but Vercel environment variables aren't available during build, only at runtime.

## Solution
Made R2 configuration lazy-loaded by:

1. Converted R2_CONFIG constant to getR2Config() function in app/src/lib/r2.ts
   - Environment variables are now only accessed when the function is called (runtime)
   - Not during module initialization (build time)

2. Updated all imports and usages to use the new function-based API

## Changes
- app/src/lib/r2.ts - Made config lazy-loaded
- app/src/app/api/episodes/[id]/route.ts - Updated to use getR2EpisodesCustomDomain()
- app/src/app/podcasts/[id]/episodes/new/page.tsx - Updated to use getR2EpisodesCustomDomain()

## Testing
- Local build passes
- Environment variables are now only accessed at runtime when R2 operations are performed
- No changes to functionality, only when configuration is loaded
