### PR TITLE
fix(build): lazy-load Supabase client to prevent build-time errors (Vibe Kanban)

### DIFF
--- a/app/src/app/api/track/download/route.ts
+++ b/app/src/app/api/track/download/route.ts
@@ -2,11 +2,6 @@ import { NextRequest, NextResponse } from 'next/server';
 import { createClient } from '@supabase/supabase-js';
 import { createHash } from 'crypto';
 
-const supabase = createClient(
-  process.env.NEXT_PUBLIC_SUPABASE_URL!,
-  process.env.NEXT_PUBLIC_SUPABASE_ANON_KEY!
-);
-
 // 1x1 transparent GIF (43 bytes) - for pixel tracking mode
 const PIXEL_GIF = Buffer.from(
   'R0lGODlhAQABAIAAAAAAAP///yH5BAEAAAAALAAAAAABAAEAAAIBRAA7',
@@ -52,6 +47,12 @@ export async function GET(request: NextRequest) {
   if (!episodeId || typeof episodeId !== 'string') {
     return returnPixelGif();
   }
+
+  // Lazy-load Supabase client (environment variables not available at build time)
+  const supabase = createClient(
+    process.env.NEXT_PUBLIC_SUPABASE_URL!,
+    process.env.NEXT_PUBLIC_SUPABASE_ANON_KEY!
+  );
 
   // Fetch episode to get the actual audio URL
   const { data: episode, error: episodeError } = await supabase


### PR DESCRIPTION
## Summary

Fixes Vercel build failures by lazy-loading the Supabase client in the download tracking endpoint. The client was being initialized at the module level, which runs during Next.js's build phase when environment variables are not available.

## Problem

Vercel builds were failing with:
```
Error: supabaseUrl is required.
    at <unknown> (.next/server/chunks/263.js:37:46961)
```

This occurred during the "Collecting page data" phase because the download tracking route was creating the Supabase client at the module level:

```typescript
const supabase = createClient(
  process.env.NEXT_PUBLIC_SUPABASE_URL!,
  process.env.NEXT_PUBLIC_SUPABASE_ANON_KEY!
);
```

Module-level code runs at build time, but Vercel environment variables are only available during request execution.

## Solution

Moved the Supabase client creation inside the GET handler, so it only runs during request handling when environment variables are available:

```typescript
export async function GET(request: NextRequest) {
  const { searchParams } = new URL(request.url);
  const episodeId = searchParams.get('episodeId');
  
  if (!episodeId || typeof episodeId !== 'string') {
    return returnPixelGif();
  }

  // Lazy-load Supabase client (environment variables not available at build time)
  const supabase = createClient(
    process.env.NEXT_PUBLIC_SUPABASE_URL!,
    process.env.NEXT_PUBLIC_SUPABASE_ANON_KEY!
  );
  
  // ... rest of handler
}
```

This is the standard pattern for Next.js API routes that require environment variables.

## Changes

- **File**: `app/src/app/api/track/download/route.ts`
- Moved `createClient()` call from module level to inside GET handler
- Added explanatory comment about lazy-loading for build-time compatibility

## Testing

The build should now complete successfully on Vercel. The runtime behavior is unchanged - the client is still created for each request, just initialized at the correct time.

---

This PR was written using [Vibe Kanban](https://vibekanban.com)