### PR TITLE
fix(display): prevent SVG icons from being stretched in flex containers (Vibe Kanban)

### DIFF
--- a/app/src/app/globals.css
+++ b/app/src/app/globals.css
@@ -42,6 +42,12 @@
   html {
     scroll-behavior: smooth;
   }
+
+  /* SVG icon constraints - prevent oversized icons */
+  svg {
+    flex-shrink: 0;
+    flex-grow: 0;
+  }
 }
 
 @layer components {


### PR DESCRIPTION
## Summary

Fixed an issue where SVG icons appeared comically oversized on authenticated pages (dashboard, episodes, podcasts) after login.

## Changes

- Added `flex-shrink: 0` and `flex-grow: 0` properties to all SVG elements in `globals.css`
- Prevents SVG icons from being stretched when inside flexbox layouts with `items-center` and `justify-center`

## Problem

Icons displayed correctly on the login/home pages but became oversized after navigating to authenticated pages. The issue occurred because SVG elements inside flex containers were being stretched by the flexbox layout, particularly when containers used `items-center` and `justify-center` alignment.

## Solution

The fix adds CSS constraints that prevent SVG elements from growing or shrinking within flex layouts while preserving their intended dimensions from Tailwind utility classes (`w-5 h-5`, `w-6 h-6`, etc.).

## Testing

- Verified icons display at correct sizes on login page
- Verified icons display at correct sizes on dashboard and authenticated pages
- Icons maintain proper sizing in flex containers with various alignment properties

---

This PR was written using [Vibe Kanban](https://vibekanban.com)