### PR TITLE
fix(auth): configure production redirect URL for email verification (Vibe Kanban)

### DIFF
--- a/app/.env.example
+++ b/app/.env.example
@@ -50,6 +50,14 @@ R2_IMAGES_CUSTOM_DOMAIN=https://images.automapod.app
 # STRIPE_PRICE_ID=your-stripe-price-id
 
 # ============================================
+# REQUIRED - Site URL
+# ============================================
+# The public URL of your site (used for email redirects, auth callbacks, etc.)
+# In development: http://localhost:3000
+# In production: https://www.automapod.app
+NEXT_PUBLIC_SITE_URL=http://localhost:3000
+
+# ============================================
 # Development Settings
 # ============================================
 NODE_ENV=development

--- a/app/src/app/api/auth/signup/route.ts
+++ b/app/src/app/api/auth/signup/route.ts
@@ -8,9 +8,14 @@ export async function POST(request: Request) {
 
   const supabase = await createClient();
 
+  const siteUrl = process.env.NEXT_PUBLIC_SITE_URL || 'http://localhost:3000';
+
   const { error } = await supabase.auth.signUp({
     email,
     password,
+    options: {
+      emailRedirectTo: siteUrl,
+    },
   });
 
   if (error) {


### PR DESCRIPTION
## Summary

Fixes email verification redirects that were pointing to `localhost:3000` instead of the production domain.

## Changes Made

1. **Updated `signup/route.ts`**: Added `emailRedirectTo` option to Supabase sign-up flow using the `NEXT_PUBLIC_SITE_URL` environment variable
2. **Updated `.env.example`**: Documented the `NEXT_PUBLIC_SITE_URL` environment variable with clear instructions for development and production

## Why This Was Needed

When users clicked the email verification link from Supabase, they were being redirected to `http://localhost:3000` instead of `https://www.automapod.app`, causing the verification to fail with an "access_denied" error.

The root cause was that the signup flow wasn't specifying a redirect URL, so Supabase was using its default email template configuration which pointed to the development URL.

## Implementation Details

The fix explicitly sets `emailRedirectTo` in the Supabase auth options:
```typescript
const siteUrl = process.env.NEXT_PUBLIC_SITE_URL || 'http://localhost:3000';

const { error } = await supabase.auth.signUp({
  email,
  password,
  options: {
    emailRedirectTo: siteUrl,
  },
});
```

This ensures that:
- Development uses `http://localhost:3000`
- Production uses `https://www.automapod.app` (already configured in Vercel environment variables)

## Testing Checklist

- [ ] Verify that new user signups receive verification emails
- [ ] Click the verification link and confirm redirect to production domain
- [ ] Confirm email verification completes successfully

---

This PR was written using [Vibe Kanban](https://vibekanban.com)