### PR TITLE
fix(auth): handle Google OAuth callback on homepage redirect (Vibe Kanban)

### DIFF
--- a/app/src/app/page.tsx
+++ b/app/src/app/page.tsx
@@ -1,6 +1,23 @@
 import Link from 'next/link';
+import { redirect } from 'next/navigation';
 
-export default function HomePage() {
+interface HomePageProps {
+  searchParams: Promise<{ code?: string; state?: string; error?: string }>;
+}
+
+export default async function HomePage({ searchParams }: HomePageProps) {
+  const params = await searchParams;
+
+  // If there's a code parameter, redirect to the auth callback handler
+  if (params?.code) {
+    const stateParam = params?.state ? `&state=${params.state}` : '';
+    redirect(`/auth/callback?code=${params.code}${stateParam}`);
+  }
+
+  // If there's an error parameter, redirect to login with error
+  if (params?.error) {
+    redirect(`/login?error=${encodeURIComponent(params.error)}`);
+  }
   return (
     <div className="min-h-screen bg-gradient-to-br from-primary/5 via-accent/5 to-secondary/5">
       <nav className="border-b border-border bg-white/80 backdrop-blur-sm sticky top-0 z-50">


### PR DESCRIPTION
## Summary
- Fixes Google OAuth login flow by handling OAuth callback parameters on the homepage
- Converts homepage to async server component to process search params
- Redirects OAuth codes and errors to proper handlers

## Problem
When users completed Google OAuth authentication, Supabase was redirecting them to `/?code=...` instead of `/auth/callback?code=...`. The homepage didn't handle these OAuth parameters, so users were stuck on the landing page without being logged in.

## Solution
Updated the homepage (`app/src/app/page.tsx`) to:
- Convert to an async server component with searchParams props
- Detect `code` parameter (OAuth callback) and redirect to `/auth/callback`
- Preserve `state` parameter if present for OAuth security
- Handle `error` parameter by redirecting to `/login` with error message

## Implementation Details
The homepage now acts as a passthrough for OAuth callbacks. When Supabase redirects with a code, the homepage immediately forwards it to the proper auth callback handler at `/auth/callback`, which exchanges the code for a session and redirects to the dashboard.

## Note
The root cause is likely in Supabase project settings where the redirect URL is configured as `/` instead of `/auth/callback`. This fix provides a workaround, but updating the Supabase URL Configuration to use `/auth/callback` directly would be the cleaner long-term solution.

---
This PR was written using [Vibe Kanban](https://vibekanban.com)