### PR TITLE
fix(upload): replace Server Action upload with presigned R2 URL (AMP-47)

### DIFF
--- a/app/next.config.ts
+++ b/app/next.config.ts
@@ -3,6 +3,11 @@ import type { NextConfig } from 'next';
 const nextConfig: NextConfig = {
   experimental: {},
   outputFileTracingRoot: __dirname,
+  // Safety net for any Server Actions that accept small payloads (forms with text only).
+  // Audio uploads bypass this entirely via presigned R2 URLs — see /api/r2/presign.
+  serverActions: {
+    bodySizeLimit: '10mb',
+  },
 };
 
 export default nextConfig;

--- a/app/package-lock.json
+++ b/app/package-lock.json
@@ -9,6 +9,7 @@
       "version": "0.1.0",
       "dependencies": {
         "@aws-sdk/client-s3": "^3.1009.0",
+        "@aws-sdk/s3-request-presigner": "^3.1017.0",
         "@supabase/ssr": "^0.5.2",
         "@supabase/supabase-js": "^2.49.4",
         "bullmq": "^5.71.0",
@@ -316,19 +317,19 @@
       }
     },
     "node_modules/@aws-sdk/core": {
-      "version": "3.973.20",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/core/-/core-3.973.20.tgz",
-      "integrity": "sha512-i3GuX+lowD892F3IuJf8o6AbyDupMTdyTxQrCJGcn71ni5hTZ82L4nQhcdumxZ7XPJRJJVHS/CR3uYOIIs0PVA==",
+      "version": "3.973.24",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/core/-/core-3.973.24.tgz",
+      "integrity": "sha512-vvf82RYQu2GidWAuQq+uIzaPz9V0gSCXVqdVzRosgl5rXcspXOpSD3wFreGGW6AYymPr97Z69kjVnLePBxloDw==",
       "license": "Apache-2.0",
       "dependencies": {
         "@aws-sdk/types": "^3.973.6",
-        "@aws-sdk/xml-builder": "^3.972.11",
-        "@smithy/core": "^3.23.11",
+        "@aws-sdk/xml-builder": "^3.972.15",
+        "@smithy/core": "^3.23.12",
         "@smithy/node-config-provider": "^4.3.12",
         "@smithy/property-provider": "^4.2.12",
         "@smithy/protocol-http": "^5.3.12",
         "@smithy/signature-v4": "^5.3.12",
-        "@smithy/smithy-client": "^4.12.5",
+        "@smithy/smithy-client": "^4.12.7",
         "@smithy/types": "^4.13.1",
         "@smithy/util-base64": "^4.3.2",
         "@smithy/util-middleware": "^4.2.12",
@@ -628,23 +629,23 @@
       }
     },
     "node_modules/@aws-sdk/middleware-sdk-s3": {
-      "version": "3.972.20",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-sdk-s3/-/middleware-sdk-s3-3.972.20.tgz",
-      "integrity": "sha512-yhva/xL5H4tWQgsBjwV+RRD0ByCzg0TcByDCLp3GXdn/wlyRNfy8zsswDtCvr1WSKQkSQYlyEzPuWkJG0f5HvQ==",
+      "version": "3.972.25",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-sdk-s3/-/middleware-sdk-s3-3.972.25.tgz",
+      "integrity": "sha512-4xJL7O+XkhbSkT4yAYshkAww+mxJvtGQneNHH0MOpe+w8Vo2z87M9z06UO3G6zPM2c3Ef2yKczvZpTgdArMHfg==",
       "license": "Apache-2.0",
       "dependencies": {
-        "@aws-sdk/core": "^3.973.20",
+        "@aws-sdk/core": "^3.973.24",
         "@aws-sdk/types": "^3.973.6",
         "@aws-sdk/util-arn-parser": "^3.972.3",
-        "@smithy/core": "^3.23.11",
+        "@smithy/core": "^3.23.12",
         "@smithy/node-config-provider": "^4.3.12",
         "@smithy/protocol-http": "^5.3.12",
         "@smithy/signature-v4": "^5.3.12",
-        "@smithy/smithy-client": "^4.12.5",
+        "@smithy/smithy-client": "^4.12.7",
         "@smithy/types": "^4.13.1",
         "@smithy/util-config-provider": "^4.2.2",
         "@smithy/util-middleware": "^4.2.12",
-        "@smithy/util-stream": "^4.5.19",
+        "@smithy/util-stream": "^4.5.20",
         "@smithy/util-utf8": "^4.2.2",
         "tslib": "^2.6.2"
       },
@@ -750,13 +751,32 @@
         "node": ">=20.0.0"
       }
     },
-    "node_modules/@aws-sdk/signature-v4-multi-region": {
-      "version": "3.996.8",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/signature-v4-multi-region/-/signature-v4-multi-region-3.996.8.tgz",
-      "integrity": "sha512-n1qYFD+tbqZuyskVaxUE+t10AUz9g3qzDw3Tp6QZDKmqsjfDmZBd4GIk2EKJJNtcCBtE5YiUjDYA+3djFAFBBg==",
+    "node_modules/@aws-sdk/s3-request-presigner": {
+      "version": "3.1017.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/s3-request-presigner/-/s3-request-presigner-3.1017.0.tgz",
+      "integrity": "sha512-PSR8VJEkCy53uhAeuvht6ub3kzfdqoTAmLliQJ63MkC/1FuMmrmqWRGoZuzZvAbpzTcZtuibSGvawDa47gsckA==",
       "license": "Apache-2.0",
       "dependencies": {
-        "@aws-sdk/middleware-sdk-s3": "^3.972.20",
+        "@aws-sdk/signature-v4-multi-region": "^3.996.13",
+        "@aws-sdk/types": "^3.973.6",
+        "@aws-sdk/util-format-url": "^3.972.8",
+        "@smithy/middleware-endpoint": "^4.4.27",
+        "@smithy/protocol-http": "^5.3.12",
+        "@smithy/smithy-client": "^4.12.7",
+        "@smithy/types": "^4.13.1",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=20.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/signature-v4-multi-region": {
+      "version": "3.996.13",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/signature-v4-multi-region/-/signature-v4-multi-region-3.996.13.tgz",
+      "integrity": "sha512-7j8rOFHHq4e9McCSuWBmBSADriW5CjPUem4inckRh/cyQGaijBwDbkNbVTgDVDWqFo29SoVVUfI6HCOnck6HZw==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@aws-sdk/middleware-sdk-s3": "^3.972.25",
         "@aws-sdk/types": "^3.973.6",
         "@smithy/protocol-http": "^5.3.12",
         "@smithy/signature-v4": "^5.3.12",
@@ -826,6 +846,21 @@
         "node": ">=20.0.0"
       }
     },
+    "node_modules/@aws-sdk/util-format-url": {
+      "version": "3.972.8",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/util-format-url/-/util-format-url-3.972.8.tgz",
+      "integrity": "sha512-J6DS9oocrgxM8xlUTTmQOuwRF6rnAGEujAN9SAzllcrQmwn5iJ58ogxy3SEhD0Q7JZvlA5jvIXBkpQRqEqlE9A==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@aws-sdk/types": "^3.973.6",
+        "@smithy/querystring-builder": "^4.2.12",
+        "@smithy/types": "^4.13.1",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=20.0.0"
+      }
+    },
     "node_modules/@aws-sdk/util-locate-window": {
       "version": "3.965.5",
       "resolved": "https://registry.npmjs.org/@aws-sdk/util-locate-window/-/util-locate-window-3.965.5.tgz",
@@ -876,13 +911,13 @@
       }
     },
     "node_modules/@aws-sdk/xml-builder": {
-      "version": "3.972.11",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/xml-builder/-/xml-builder-3.972.11.tgz",
-      "integrity": "sha512-iitV/gZKQMvY9d7ovmyFnFuTHbBAtrmLnvaSb/3X8vOKyevwtpmEtyc8AdhVWZe0pI/1GsHxlEvQeOePFzy7KQ==",
+      "version": "3.972.15",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/xml-builder/-/xml-builder-3.972.15.tgz",
+      "integrity": "sha512-PxMRlCFNiQnke9YR29vjFQwz4jq+6Q04rOVFeTDR2K7Qpv9h9FOWOxG+zJjageimYbWqE3bTuLjmryWHAWbvaA==",
       "license": "Apache-2.0",
       "dependencies": {
         "@smithy/types": "^4.13.1",
-        "fast-xml-parser": "5.4.1",
+        "fast-xml-parser": "5.5.8",
         "tslib": "^2.6.2"
       },
       "engines": {
@@ -1923,9 +1958,9 @@
       }
     },
     "node_modules/@smithy/core": {
-      "version": "3.23.11",
-      "resolved": "https://registry.npmjs.org/@smithy/core/-/core-3.23.11.tgz",
-      "integrity": "sha512-952rGf7hBRnhUIaeLp6q4MptKW8sPFe5VvkoZ5qIzFAtx6c/QZ/54FS3yootsyUSf9gJX/NBqEBNdNR7jMIlpQ==",
+      "version": "3.23.12",
+      "resolved": "https://registry.npmjs.org/@smithy/core/-/core-3.23.12.tgz",
+      "integrity": "sha512-o9VycsYNtgC+Dy3I0yrwCqv9CWicDnke0L7EVOrZtJpjb2t0EjaEofmMrYc0T1Kn3yk32zm6cspxF9u9Bj7e5w==",
       "license": "Apache-2.0",
       "dependencies": {
         "@smithy/protocol-http": "^5.3.12",
@@ -1934,7 +1969,7 @@
         "@smithy/util-base64": "^4.3.2",
         "@smithy/util-body-length-browser": "^4.2.2",
         "@smithy/util-middleware": "^4.2.12",
-        "@smithy/util-stream": "^4.5.19",
+        "@smithy/util-stream": "^4.5.20",
         "@smithy/util-utf8": "^4.2.2",
         "@smithy/uuid": "^1.1.2",
         "tslib": "^2.6.2"
@@ -2143,13 +2178,13 @@
       }
     },
     "node_modules/@smithy/middleware-endpoint": {
-      "version": "4.4.25",
-      "resolved": "https://registry.npmjs.org/@smithy/middleware-endpoint/-/middleware-endpoint-4.4.25.tgz",
-      "integrity": "sha512-dqjLwZs2eBxIUG6Qtw8/YZ4DvzHGIf0DA18wrgtfP6a50UIO7e2nY0FPdcbv5tVJKqWCCU5BmGMOUwT7Puan+A==",
+      "version": "4.4.27",
+      "resolved": "https://registry.npmjs.org/@smithy/middleware-endpoint/-/middleware-endpoint-4.4.27.tgz",
+      "integrity": "sha512-T3TFfUgXQlpcg+UdzcAISdZpj4Z+XECZ/cefgA6wLBd6V4lRi0svN2hBouN/be9dXQ31X4sLWz3fAQDf+nt6BA==",
       "license": "Apache-2.0",
       "dependencies": {
-        "@smithy/core": "^3.23.11",
-        "@smithy/middleware-serde": "^4.2.14",
+        "@smithy/core": "^3.23.12",
+        "@smithy/middleware-serde": "^4.2.15",
         "@smithy/node-config-provider": "^4.3.12",
         "@smithy/shared-ini-file-loader": "^4.4.7",
         "@smithy/types": "^4.13.1",
@@ -2182,12 +2217,12 @@
       }
     },
     "node_modules/@smithy/middleware-serde": {
-      "version": "4.2.14",
-      "resolved": "https://registry.npmjs.org/@smithy/middleware-serde/-/middleware-serde-4.2.14.tgz",
-      "integrity": "sha512-+CcaLoLa5apzSRtloOyG7lQvkUw2ZDml3hRh4QiG9WyEPfW5Ke/3tPOPiPjUneuT59Tpn8+c3RVaUvvkkwqZwg==",
+      "version": "4.2.15",
+      "resolved": "https://registry.npmjs.org/@smithy/middleware-serde/-/middleware-serde-4.2.15.tgz",
+      "integrity": "sha512-ExYhcltZSli0pgAKOpQQe1DLFBLryeZ22605y/YS+mQpdNWekum9Ujb/jMKfJKgjtz1AZldtwA/wCYuKJgjjlg==",
       "license": "Apache-2.0",
       "dependencies": {
-        "@smithy/core": "^3.23.11",
+        "@smithy/core": "^3.23.12",
         "@smithy/protocol-http": "^5.3.12",
         "@smithy/types": "^4.13.1",
         "tslib": "^2.6.2"
@@ -2225,9 +2260,9 @@
       }
     },
     "node_modules/@smithy/node-http-handler": {
-      "version": "4.4.16",
-      "resolved": "https://registry.npmjs.org/@smithy/node-http-handler/-/node-http-handler-4.4.16.tgz",
-      "integrity": "sha512-ULC8UCS/HivdCB3jhi+kLFYe4B5gxH2gi9vHBfEIiRrT2jfKiZNiETJSlzRtE6B26XbBHjPtc8iZKSNqMol9bw==",
+      "version": "4.5.0",
+      "resolved": "https://registry.npmjs.org/@smithy/node-http-handler/-/node-http-handler-4.5.0.tgz",
+      "integrity": "sha512-Rnq9vQWiR1+/I6NZZMNzJHV6pZYyEHt2ZnuV3MG8z2NNenC4i/8Kzttz7CjZiHSmsN5frhXhg17z3Zqjjhmz1A==",
       "license": "Apache-2.0",
       "dependencies": {
         "@smithy/abort-controller": "^4.2.12",
@@ -2338,17 +2373,17 @@
       }
     },
     "node_modules/@smithy/smithy-client": {
-      "version": "4.12.5",
-      "resolved": "https://registry.npmjs.org/@smithy/smithy-client/-/smithy-client-4.12.5.tgz",
-      "integrity": "sha512-UqwYawyqSr/aog8mnLnfbPurS0gi4G7IYDcD28cUIBhsvWs1+rQcL2IwkUQ+QZ7dibaoRzhNF99fAQ9AUcO00w==",
+      "version": "4.12.7",
+      "resolved": "https://registry.npmjs.org/@smithy/smithy-client/-/smithy-client-4.12.7.tgz",
+      "integrity": "sha512-q3gqnwml60G44FECaEEsdQMplYhDMZYCtYhMCzadCnRnnHIobZJjegmdoUo6ieLQlPUzvrMdIJUpx6DoPmzANQ==",
       "license": "Apache-2.0",
       "dependencies": {
-        "@smithy/core": "^3.23.11",
-        "@smithy/middleware-endpoint": "^4.4.25",
+        "@smithy/core": "^3.23.12",
+        "@smithy/middleware-endpoint": "^4.4.27",
         "@smithy/middleware-stack": "^4.2.12",
         "@smithy/protocol-http": "^5.3.12",
         "@smithy/types": "^4.13.1",
-        "@smithy/util-stream": "^4.5.19",
+        "@smithy/util-stream": "^4.5.20",
         "tslib": "^2.6.2"
       },
       "engines": {
@@ -2531,13 +2566,13 @@
       }
     },
     "node_modules/@smithy/util-stream": {
-      "version": "4.5.19",
-      "resolved": "https://registry.npmjs.org/@smithy/util-stream/-/util-stream-4.5.19.tgz",
-      "integrity": "sha512-v4sa+3xTweL1CLO2UP0p7tvIMH/Rq1X4KKOxd568mpe6LSLMQCnDHs4uv7m3ukpl3HvcN2JH6jiCS0SNRXKP/w==",
+      "version": "4.5.20",
+      "resolved": "https://registry.npmjs.org/@smithy/util-stream/-/util-stream-4.5.20.tgz",
+      "integrity": "sha512-4yXLm5n/B5SRBR2p8cZ90Sbv4zL4NKsgxdzCzp/83cXw2KxLEumt5p+GAVyRNZgQOSrzXn9ARpO0lUe8XSlSDw==",
       "license": "Apache-2.0",
       "dependencies": {
         "@smithy/fetch-http-handler": "^5.3.15",
-        "@smithy/node-http-handler": "^4.4.16",
+        "@smithy/node-http-handler": "^4.5.0",
         "@smithy/types": "^4.13.1",
         "@smithy/util-base64": "^4.3.2",
         "@smithy/util-buffer-from": "^4.2.2",
@@ -5296,9 +5331,9 @@
       "license": "MIT"
     },
     "node_modules/fast-xml-builder": {
-      "version": "1.1.3",
-      "resolved": "https://registry.npmjs.org/fast-xml-builder/-/fast-xml-builder-1.1.3.tgz",
-      "integrity": "sha512-1o60KoFw2+LWKQu3IdcfcFlGTW4dpqEWmjhYec6H82AYZU2TVBXep6tMl8Z1Y+wM+ZrzCwe3BZ9Vyd9N2rIvmg==",
+      "version": "1.1.4",
+      "resolved": "https://registry.npmjs.org/fast-xml-builder/-/fast-xml-builder-1.1.4.tgz",
+      "integrity": "sha512-f2jhpN4Eccy0/Uz9csxh3Nu6q4ErKxf0XIsasomfOihuSUa3/xw6w8dnOtCDgEItQFJG8KyXPzQXzcODDrrbOg==",
       "funding": [
         {
           "type": "github",
@@ -5311,9 +5346,9 @@
       }
     },
     "node_modules/fast-xml-parser": {
-      "version": "5.4.1",
-      "resolved": "https://registry.npmjs.org/fast-xml-parser/-/fast-xml-parser-5.4.1.tgz",
-      "integrity": "sha512-BQ30U1mKkvXQXXkAGcuyUA/GA26oEB7NzOtsxCDtyu62sjGw5QraKFhx2Em3WQNjPw9PG6MQ9yuIIgkSDfGu5A==",
+      "version": "5.5.8",
+      "resolved": "https://registry.npmjs.org/fast-xml-parser/-/fast-xml-parser-5.5.8.tgz",
+      "integrity": "sha512-Z7Fh2nVQSb2d+poDViM063ix2ZGt9jmY1nWhPfHBOK2Hgnb/OW3P4Et3P/81SEej0J7QbWtJqxO05h8QYfK7LQ==",
       "funding": [
         {
           "type": "github",
@@ -5322,8 +5357,9 @@
       ],
       "license": "MIT",
       "dependencies": {
-        "fast-xml-builder": "^1.0.0",
-        "strnum": "^2.1.2"
+        "fast-xml-builder": "^1.1.4",
+        "path-expression-matcher": "^1.2.0",
+        "strnum": "^2.2.0"
       },
       "bin": {
         "fxparser": "src/cli/cli.js"
@@ -7389,9 +7425,9 @@
       }
     },
     "node_modules/path-expression-matcher": {
-      "version": "1.1.3",
-      "resolved": "https://registry.npmjs.org/path-expression-matcher/-/path-expression-matcher-1.1.3.tgz",
-      "integrity": "sha512-qdVgY8KXmVdJZRSS1JdEPOKPdTiEK/pi0RkcT2sw1RhXxohdujUlJFPuS1TSkevZ9vzd3ZlL7ULl1MHGTApKzQ==",
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/path-expression-matcher/-/path-expression-matcher-1.2.0.tgz",
+      "integrity": "sha512-DwmPWeFn+tq7TiyJ2CxezCAirXjFxvaiD03npak3cRjlP9+OjTmSy1EpIrEbh+l6JgUundniloMLDQ/6VTdhLQ==",
       "funding": [
         {
           "type": "github",
@@ -8218,9 +8254,9 @@
       }
     },
     "node_modules/strnum": {
-      "version": "2.2.0",
-      "resolved": "https://registry.npmjs.org/strnum/-/strnum-2.2.0.tgz",
-      "integrity": "sha512-Y7Bj8XyJxnPAORMZj/xltsfo55uOiyHcU2tnAVzHUnSJR/KsEX+9RoDeXEnsXtl/CX4fAcrt64gZ13aGaWPeBg==",
+      "version": "2.2.2",
+      "resolved": "https://registry.npmjs.org/strnum/-/strnum-2.2.2.tgz",
+      "integrity": "sha512-DnR90I+jtXNSTXWdwrEy9FakW7UX+qUZg28gj5fk2vxxl7uS/3bpI4fjFYVmdK9etptYBPNkpahuQnEwhwECqA==",
       "funding": [
         {
           "type": "github",

--- a/app/package.json
+++ b/app/package.json
@@ -15,6 +15,7 @@
   },
   "dependencies": {
     "@aws-sdk/client-s3": "^3.1009.0",
+    "@aws-sdk/s3-request-presigner": "^3.1017.0",
     "@supabase/ssr": "^0.5.2",
     "@supabase/supabase-js": "^2.49.4",
     "bullmq": "^5.71.0",

--- a/app/src/app/api/episodes/route.ts
+++ b/app/src/app/api/episodes/route.ts
@@ -1,5 +1,84 @@
-import { NextResponse } from 'next/server';
+import { NextRequest, NextResponse } from 'next/server';
 import { createClient } from '@/lib/supabase/server';
+
+/**
+ * POST /api/episodes
+ *
+ * Creates an episode record after the audio file has been uploaded directly
+ * to R2 via a presigned URL. The body contains only metadata — no file bytes.
+ *
+ * Body: { title: string, description?: string, audioUrl: string, podcastId: string }
+ * Returns: { episode } with status 201
+ */
+export async function POST(request: NextRequest) {
+  try {
+    const supabase = await createClient();
+
+    const { data: { user }, error: authError } = await supabase.auth.getUser();
+    if (authError || !user) {
+      return NextResponse.json({ error: 'Authentication required' }, { status: 401 });
+    }
+
+    const body = await request.json() as {
+      title?: string;
+      description?: string;
+      audioUrl?: string;
+      podcastId?: string;
+    };
+
+    const { title, description, audioUrl, podcastId } = body;
+
+    if (!title?.trim()) {
+      return NextResponse.json({ error: 'Title is required' }, { status: 400 });
+    }
+    if (!audioUrl) {
+      return NextResponse.json({ error: 'audioUrl is required' }, { status: 400 });
+    }
+    if (!podcastId) {
+      return NextResponse.json({ error: 'podcastId is required' }, { status: 400 });
+    }
+
+    // Verify the authenticated user owns this podcast
+    const { data: podcast } = await supabase
+      .from('podcasts')
+      .select('id')
+      .eq('id', podcastId)
+      .eq('user_id', user.id)
+      .single();
+
+    if (!podcast) {
+      return NextResponse.json(
+        { error: 'Podcast not found or access denied' },
+        { status: 403 }
+      );
+    }
+
+    const { data: episode, error: insertError } = await supabase
+      .from('episodes')
+      .insert({
+        title: title.trim(),
+        description: description?.trim() || '',
+        audio_url: audioUrl,
+        duration_seconds: null,
+        transcript_status: 'pending',
+        podcast_id: podcastId,
+      })
+      .select()
+      .single();
+
+    if (insertError || !episode) {
+      return NextResponse.json(
+        { error: insertError?.message || 'Failed to create episode' },
+        { status: 500 }
+      );
+    }
+
+    return NextResponse.json({ episode }, { status: 201 });
+  } catch (error) {
+    console.error('Create episode error:', error);
+    return NextResponse.json({ error: 'Internal server error' }, { status: 500 });
+  }
+}
 
 export async function GET(request: Request) {
   try {

--- a/app/src/app/api/r2/presign/route.ts
+++ b/app/src/app/api/r2/presign/route.ts
@@ -1,0 +1,85 @@
+import { NextRequest, NextResponse } from 'next/server';
+import { createClient } from '@/lib/supabase/server';
+import {
+  generateEpisodeKey,
+  getPresignedUploadUrl,
+  getR2EpisodesCustomDomain,
+  isValidAudioFile,
+  isValidFileSize,
+} from '@/lib/r2';
+
+/**
+ * POST /api/r2/presign
+ *
+ * Returns a short-lived presigned PUT URL for direct browser → R2 uploads.
+ * The audio file never transits the Next.js server.
+ *
+ * Body: { filename: string, contentType: string, fileSize: number, podcastId: string }
+ * Returns: { presignedUrl: string, key: string, audioUrl: string }
+ */
+export async function POST(request: NextRequest) {
+  try {
+    const supabase = await createClient();
+
+    const { data: { user }, error: authError } = await supabase.auth.getUser();
+    if (authError || !user) {
+      return NextResponse.json({ error: 'Authentication required' }, { status: 401 });
+    }
+
+    const body = await request.json() as {
+      filename?: string;
+      contentType?: string;
+      fileSize?: number;
+      podcastId?: string;
+    };
+
+    const { filename, contentType, fileSize, podcastId } = body;
+
+    if (!filename || !contentType || fileSize === undefined || !podcastId) {
+      return NextResponse.json(
+        { error: 'filename, contentType, fileSize, and podcastId are required' },
+        { status: 400 }
+      );
+    }
+
+    // Validate file type via a mock File object (reuse existing validators)
+    const mockFile = { type: contentType, size: fileSize } as File;
+    if (!isValidAudioFile(mockFile)) {
+      return NextResponse.json(
+        { error: 'Invalid file type. Please upload an audio file (MP3, M4A, WAV, or OGG)' },
+        { status: 422 }
+      );
+    }
+    if (!isValidFileSize(mockFile)) {
+      return NextResponse.json(
+        { error: 'File size exceeds 500MB limit' },
+        { status: 422 }
+      );
+    }
+
+    // Verify the authenticated user owns this podcast
+    const { data: podcast } = await supabase
+      .from('podcasts')
+      .select('id')
+      .eq('id', podcastId)
+      .eq('user_id', user.id)
+      .single();
+
+    if (!podcast) {
+      return NextResponse.json(
+        { error: 'Podcast not found or access denied' },
+        { status: 403 }
+      );
+    }
+
+    const episodeId = crypto.randomUUID();
+    const key = generateEpisodeKey(episodeId, filename);
+    const presignedUrl = await getPresignedUploadUrl(key, contentType);
+    const audioUrl = `${getR2EpisodesCustomDomain()}/${key}`;
+
+    return NextResponse.json({ presignedUrl, key, audioUrl });
+  } catch (error) {
+    console.error('Presign error:', error);
+    return NextResponse.json({ error: 'Failed to generate upload URL' }, { status: 500 });
+  }
+}

--- a/app/src/app/podcasts/[id]/episodes/new/page.tsx
+++ b/app/src/app/podcasts/[id]/episodes/new/page.tsx
@@ -1,7 +1,6 @@
 import { redirect } from 'next/navigation';
 import Link from 'next/link';
 import { createClient } from '@/lib/supabase/server';
-import { uploadToR2, isValidAudioFile, isValidFileSize, getR2EpisodesCustomDomain } from '@/lib/r2';
 import { SimpleUploadForm } from '@/components/simple-upload-form';
 
 export const dynamic = 'force-dynamic';
@@ -26,99 +25,6 @@ async function getPodcast(podcastId: string) {
     .single();
 
   return podcast;
-}
-
-async function uploadEpisode(
-  prevState: { error?: string } | null,
-  podcastId: string,
-  formData: FormData
-): Promise<{ error?: string } | null> {
-  'use server';
-
-  const supabase = await createClient();
-
-  const { data: { user } } = await supabase.auth.getUser();
-  if (!user) {
-    return { error: 'You must be logged in to upload an episode' };
-  }
-
-  // Verify user owns this podcast
-  const { data: podcast } = await supabase
-    .from('podcasts')
-    .select('id')
-    .eq('id', podcastId)
-    .eq('user_id', user.id)
-    .single();
-
-  if (!podcast) {
-    return { error: 'Podcast not found or access denied' };
-  }
-
-  const fileValue = formData.get('audio');
-  const title = formData.get('title') as string;
-  const description = formData.get('description') as string || '';
-
-  if (!title) {
-    return { error: 'Title is required' };
-  }
-
-  if (!(fileValue instanceof File) || fileValue.size === 0) {
-    return { error: 'Audio file is required' };
-  }
-
-  const file = fileValue;
-
-  // Validate file type
-  if (!isValidAudioFile(file)) {
-    return { error: 'Invalid file type. Please upload an audio file (MP3, M4A, WAV, or OGG)' };
-  }
-
-  // Validate file size (500MB max)
-  if (!isValidFileSize(file)) {
-    return { error: 'File size exceeds 500MB limit' };
-  }
-
-  // Generate a temporary episode ID for R2 upload path
-  const tempEpisodeId = crypto.randomUUID();
-
-  let audioUrl: string;
-  try {
-    // Upload to R2 first to get the audio URL
-    audioUrl = await uploadToR2(file, tempEpisodeId, file.name);
-  } catch (error) {
-    console.error('R2 upload failed:', error);
-    return { error: `Failed to upload audio file: ${error instanceof Error ? error.message : 'Unknown error'}` };
-  }
-
-  // Now create the episode record with the actual audio URL
-  const { data: episode, error: insertError } = await supabase
-    .from('episodes')
-    .insert({
-      title,
-      description,
-      audio_url: audioUrl,
-      duration_seconds: null,
-      transcript_status: 'pending',
-      podcast_id: podcastId,  // Always set - no standalone episodes
-    })
-    .select()
-    .single();
-
-  if (insertError || !episode) {
-    // If database insert fails, try to clean up the uploaded file
-    try {
-      const { deleteFromR2 } = await import('@/lib/r2');
-      if (audioUrl.startsWith(getR2EpisodesCustomDomain())) {
-        const key = audioUrl.replace(getR2EpisodesCustomDomain(), '').replace(/^\//, '');
-        await deleteFromR2(key);
-      }
-    } catch (cleanupError) {
-      console.error('Failed to cleanup R2 file after DB error:', cleanupError);
-    }
-    return { error: insertError?.message || 'Failed to create episode' };
-  }
-
-  redirect(`/podcasts/${podcastId}/episodes`);
 }
 
 export default async function NewEpisodePage({ params }: Props) {
@@ -178,10 +84,7 @@ export default async function NewEpisodePage({ params }: Props) {
 
         <SimpleUploadForm
           podcastTitle={podcast.title}
-          action={async (prevState, formData) => {
-            'use server';
-            return uploadEpisode(prevState, podcast.id, formData);
-          }}
+          podcastId={podcast.id}
           backUrl={`/podcasts/${podcast.id}/episodes`}
         />
       </main>

--- a/app/src/components/simple-upload-form.tsx
+++ b/app/src/components/simple-upload-form.tsx
@@ -1,56 +1,157 @@
 'use client';
 
-import { useFormState, useFormStatus } from 'react-dom';
+import { useState, useRef } from 'react';
+import { useRouter } from 'next/navigation';
+
+type UploadPhase = 'idle' | 'presigning' | 'uploading' | 'saving' | 'error';
 
 interface SimpleUploadFormProps {
   podcastTitle: string;
-  action: (prevState: { error?: string } | null, formData: FormData) => Promise<{ error?: string } | null>;
+  podcastId: string;
   backUrl: string;
 }
 
-function SubmitButton() {
-  const { pending } = useFormStatus();
+export function SimpleUploadForm({ podcastTitle, podcastId, backUrl }: SimpleUploadFormProps) {
+  const router = useRouter();
+  const [phase, setPhase] = useState<UploadPhase>('idle');
+  const [progress, setProgress] = useState(0);
+  const [error, setError] = useState<string | null>(null);
+  const abortRef = useRef<XMLHttpRequest | null>(null);
 
-  return (
-    <button
-      type="submit"
-      disabled={pending}
-      className="px-4 py-2 border border-transparent rounded-md shadow-sm text-sm font-medium text-white bg-blue-600 hover:bg-blue-700 focus:outline-none focus:ring-2 focus:ring-offset-2 focus:ring-blue-500 disabled:opacity-50 disabled:cursor-not-allowed"
-    >
-      {pending ? 'Uploading...' : 'Upload Episode'}
-    </button>
-  );
-}
+  const isSubmitting = phase !== 'idle' && phase !== 'error';
 
-export function SimpleUploadForm({ podcastTitle, action, backUrl }: SimpleUploadFormProps) {
-  const [state, formAction] = useFormState<{ error?: string } | null, FormData>(action, null);
-  const errorMessage = state?.error;
+  async function handleSubmit(e: React.FormEvent<HTMLFormElement>) {
+    e.preventDefault();
+    setError(null);
+    setProgress(0);
+
+    const form = e.currentTarget;
+    const title = (form.elements.namedItem('title') as HTMLInputElement).value.trim();
+    const description = (form.elements.namedItem('description') as HTMLTextAreaElement).value.trim();
+    const fileInput = form.elements.namedItem('audio') as HTMLInputElement;
+    const file = fileInput.files?.[0];
+
+    if (!title) {
+      setError('Title is required');
+      return;
+    }
+    if (!file) {
+      setError('Audio file is required');
+      return;
+    }
+
+    try {
+      // ── Phase 1: get presigned URL ─────────────────────────────────────
+      setPhase('presigning');
+
+      const presignRes = await fetch('/api/r2/presign', {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({
+          filename: file.name,
+          contentType: file.type || 'audio/mpeg',
+          fileSize: file.size,
+          podcastId,
+        }),
+      });
+
+      if (!presignRes.ok) {
+        const json = await presignRes.json() as { error?: string };
+        throw new Error(json.error ?? 'Failed to prepare upload');
+      }
+
+      const { presignedUrl, audioUrl } = await presignRes.json() as {
+        presignedUrl: string;
+        audioUrl: string;
+      };
+
+      // ── Phase 2: upload file directly to R2 ───────────────────────────
+      setPhase('uploading');
+
+      await new Promise<void>((resolve, reject) => {
+        const xhr = new XMLHttpRequest();
+        abortRef.current = xhr;
+
+        xhr.upload.addEventListener('progress', (event) => {
+          if (event.lengthComputable) {
+            setProgress(Math.round((event.loaded / event.total) * 100));
+          }
+        });
+
+        xhr.addEventListener('load', () => {
+          if (xhr.status >= 200 && xhr.status < 300) {
+            resolve();
+          } else {
+            reject(new Error(`Upload failed (HTTP ${xhr.status})`));
+          }
+        });
+
+        xhr.addEventListener('error', () => reject(new Error('Upload failed — network error')));
+        xhr.addEventListener('abort', () => reject(new Error('Upload cancelled')));
+
+        xhr.open('PUT', presignedUrl);
+        xhr.setRequestHeader('Content-Type', file.type || 'audio/mpeg');
+        xhr.send(file);
+      });
+
+      // ── Phase 3: create episode record ────────────────────────────────
+      setPhase('saving');
+
+      const createRes = await fetch('/api/episodes', {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({ title, description, audioUrl, podcastId }),
+      });
+
+      if (!createRes.ok) {
+        const json = await createRes.json() as { error?: string };
+        throw new Error(json.error ?? 'Failed to save episode');
+      }
+
+      // Success — redirect to episode list
+      router.push(backUrl);
+      router.refresh();
+    } catch (err) {
+      setPhase('error');
+      setError(err instanceof Error ? err.message : 'An unexpected error occurred');
+    }
+  }
+
+  const phaseLabel: Record<UploadPhase, string> = {
+    idle: 'Upload Episode',
+    presigning: 'Preparing upload…',
+    uploading: `Uploading… ${progress}%`,
+    saving: 'Saving episode…',
+    error: 'Upload Episode',
+  };
 
   return (
     <div>
       <div className="mb-8">
         <h1 className="text-3xl font-bold text-gray-900">Upload New Episode</h1>
-        <p className="text-gray-600 mt-1">Add a new episode to <span className="font-semibold">{podcastTitle}</span></p>
+        <p className="text-gray-600 mt-1">
+          Add a new episode to <span className="font-semibold">{podcastTitle}</span>
+        </p>
       </div>
 
-      {errorMessage && (
+      {error && (
         <div className="mb-4 bg-red-50 border border-red-200 rounded-md p-4" role="alert">
           <div className="flex">
             <div className="flex-shrink-0">
               <svg className="h-5 w-5 text-red-400" viewBox="0 0 20 20" fill="currentColor" aria-hidden="true">
-                <path fillRule="evenodd" d="M10 18a8 8 0 100-16 8 8 0 00016zm1-8a1 1 0 11-2 0 1 1 0 012 0zm-1-9a1 1 0 00-2 0v4a1 1 0 112 0v-4z" clipRule="evenodd" />
+                <path fillRule="evenodd" d="M10 18a8 8 0 100-16 8 8 0 000 16zm1-8a1 1 0 11-2 0 1 1 0 012 0zm-1-9a1 1 0 00-2 0v4a1 1 0 112 0V4z" clipRule="evenodd" />
               </svg>
             </div>
             <div className="ml-3">
               <h3 className="text-sm font-medium text-red-800">Error</h3>
-              <div className="mt-2 text-sm text-red-700">{errorMessage}</div>
+              <div className="mt-2 text-sm text-red-700">{error}</div>
             </div>
           </div>
         </div>
       )}
 
       <div className="bg-white shadow rounded-lg p-6">
-        <form action={formAction} className="space-y-6">
+        <form onSubmit={handleSubmit} className="space-y-6">
           <div>
             <label htmlFor="title" className="block text-sm font-medium text-gray-700">
               Title <span className="text-red-500">*</span>
@@ -60,7 +161,8 @@ export function SimpleUploadForm({ podcastTitle, action, backUrl }: SimpleUpload
               name="title"
               id="title"
               required
-              className="mt-1 block w-full px-3 py-2 border border-gray-300 rounded-md shadow-sm focus:outline-none focus:ring-blue-500 focus:border-blue-500 sm:text-sm"
+              disabled={isSubmitting}
+              className="mt-1 block w-full px-3 py-2 border border-gray-300 rounded-md shadow-sm focus:outline-none focus:ring-blue-500 focus:border-blue-500 sm:text-sm disabled:opacity-50"
               placeholder="Episode title"
             />
           </div>
@@ -73,7 +175,8 @@ export function SimpleUploadForm({ podcastTitle, action, backUrl }: SimpleUpload
               name="description"
               id="description"
               rows={3}
-              className="mt-1 block w-full px-3 py-2 border border-gray-300 rounded-md shadow-sm focus:outline-none focus:ring-blue-500 focus:border-blue-500 sm:text-sm"
+              disabled={isSubmitting}
+              className="mt-1 block w-full px-3 py-2 border border-gray-300 rounded-md shadow-sm focus:outline-none focus:ring-blue-500 focus:border-blue-500 sm:text-sm disabled:opacity-50"
               placeholder="Episode description"
             />
           </div>
@@ -88,22 +191,44 @@ export function SimpleUploadForm({ podcastTitle, action, backUrl }: SimpleUpload
               id="audio"
               accept="audio/*"
               required
-              className="mt-1 block w-full px-3 py-2 border border-gray-300 rounded-md shadow-sm focus:outline-none focus:ring-blue-500 focus:border-blue-500 sm:text-sm"
+              disabled={isSubmitting}
+              className="mt-1 block w-full px-3 py-2 border border-gray-300 rounded-md shadow-sm focus:outline-none focus:ring-blue-500 focus:border-blue-500 sm:text-sm disabled:opacity-50"
             />
-            <p className="mt-1 text-sm text-gray-500">
-              MP3, M4A, WAV, or OGG (max 500MB)
-            </p>
+            <p className="mt-1 text-sm text-gray-500">MP3, M4A, WAV, or OGG (max 500MB)</p>
           </div>
+
+          {/* Upload progress bar */}
+          {phase === 'uploading' && (
+            <div>
+              <div className="flex justify-between text-sm text-gray-600 mb-1">
+                <span>Uploading audio…</span>
+                <span>{progress}%</span>
+              </div>
+              <div className="w-full bg-gray-200 rounded-full h-2">
+                <div
+                  className="bg-blue-600 h-2 rounded-full transition-all duration-200"
+                  style={{ width: `${progress}%` }}
+                />
+              </div>
+            </div>
+          )}
 
           <div className="flex justify-end gap-3">
             <button
               type="button"
-              onClick={() => window.location.href = backUrl}
-              className="px-4 py-2 border border-gray-300 rounded-md shadow-sm text-sm font-medium text-gray-700 bg-white hover:bg-gray-50 focus:outline-none focus:ring-2 focus:ring-offset-2 focus:ring-blue-500"
+              disabled={isSubmitting}
+              onClick={() => router.push(backUrl)}
+              className="px-4 py-2 border border-gray-300 rounded-md shadow-sm text-sm font-medium text-gray-700 bg-white hover:bg-gray-50 focus:outline-none focus:ring-2 focus:ring-offset-2 focus:ring-blue-500 disabled:opacity-50 disabled:cursor-not-allowed"
             >
               Cancel
             </button>
-            <SubmitButton />
+            <button
+              type="submit"
+              disabled={isSubmitting}
+              className="px-4 py-2 border border-transparent rounded-md shadow-sm text-sm font-medium text-white bg-blue-600 hover:bg-blue-700 focus:outline-none focus:ring-2 focus:ring-offset-2 focus:ring-blue-500 disabled:opacity-50 disabled:cursor-not-allowed"
+            >
+              {phaseLabel[phase]}
+            </button>
           </div>
         </form>
       </div>

--- a/app/src/lib/r2.ts
+++ b/app/src/lib/r2.ts
@@ -6,6 +6,7 @@
  */
 
 import { S3Client, PutObjectCommand, DeleteObjectCommand } from '@aws-sdk/client-s3';
+import { getSignedUrl } from '@aws-sdk/s3-request-presigner';
 
 // Environment variables with validation
 const getRequiredEnv = (name: string): string => {
@@ -172,6 +173,24 @@ export function isValidAudioFile(file: File): boolean {
 export function isValidFileSize(file: File, maxSizeMB: number = 500): boolean {
   const maxSizeBytes = maxSizeMB * 1024 * 1024;
   return file.size <= maxSizeBytes;
+}
+
+/**
+ * Generate a presigned PUT URL for direct-to-R2 browser uploads.
+ * The URL is valid for 15 minutes.
+ *
+ * @param key    - The R2 storage key (from generateEpisodeKey)
+ * @param contentType - MIME type of the file being uploaded
+ * @returns A presigned URL the client can PUT to directly
+ */
+export async function getPresignedUploadUrl(key: string, contentType: string): Promise<string> {
+  const config = getR2Config();
+  const command = new PutObjectCommand({
+    Bucket: config.bucketName,
+    Key: key,
+    ContentType: contentType,
+  });
+  return getSignedUrl(getR2Client(), command, { expiresIn: 900 });
 }
 
 // Re-export constants for backward compatibility (lazy-loaded)

--- a/tickets/AMP-47-fix-episode-upload-body-limit.md
+++ b/tickets/AMP-47-fix-episode-upload-body-limit.md
@@ -1,0 +1,108 @@
+# AMP-47: Fix Episode Upload Failing with 1 MB Body Size Limit
+
+**Type**: bugfix
+**Priority**: P0 — blocks core functionality
+**Status**: Open
+
+## Error
+
+```
+Uncaught Exception: Error: Body exceeded 1 MB limit.
+To configure the body size limit for Server Actions, see:
+https://nextjs.org/docs/app/api-reference/next-config-js/serverActions#bodysizelimit
+    at Transform.transform [as _transform] (next-server/app-page.runtime.prod.js)
+```
+
+## Root Cause
+
+The episode upload form at `/podcasts/[id]/episodes/new` submits the audio
+file via a Next.js **Server Action** (`'use server'`). Next.js applies a
+default `bodySizeLimit` of **1 MB** to all Server Actions. Any audio file
+larger than 1 MB — which is essentially every real podcast episode — hits
+this limit and throws before the action can run.
+
+**File**: `app/src/app/podcasts/[id]/episodes/new/page.tsx`
+The `uploadEpisode` Server Action receives `formData` containing the raw
+audio file blob, which is streamed through the Next.js server.
+
+## Two Possible Fixes
+
+### Option A — Quick fix: raise `bodySizeLimit` in `next.config.ts`
+
+```typescript
+// next.config.ts
+const nextConfig: NextConfig = {
+  experimental: {
+    serverActions: {
+      bodySizeLimit: '500mb',  // match stated 500MB upload limit
+    },
+  },
+};
+```
+
+**Pros**: One-line change, unblocks uploads immediately.
+**Cons**: Routes every audio upload (up to 500 MB) through the Next.js
+server process and Vercel's function runtime. This means:
+- Higher memory usage per upload
+- Ties up a serverless function slot for the full upload duration
+- Vercel functions have a 4.5 MB request body limit on hobby plans, and
+  a 4 GB limit on Pro — but streaming to R2 still traverses the function
+
+### Option B — Proper fix: presigned URL direct-to-R2 upload (recommended)
+
+Upload flow becomes:
+1. Client calls `POST /api/r2/presign` with `filename` and `contentType`
+   → returns a presigned PUT URL (signed with R2 credentials, 15-min TTL)
+2. Client uploads the file **directly to R2** via `fetch(presignedUrl, { method: 'PUT', body: file })`
+   — Next.js server is never in the data path
+3. On upload completion, client calls the Server Action with just the
+   returned R2 key + episode metadata (title, description)
+   → Server Action creates the database record and redirects
+
+**Pros**:
+- Audio bytes never transit the Next.js server
+- No body size limit issue — upload goes browser → R2 directly
+- Scales to large files without tying up serverless function memory
+- Upload progress can be reported to the user (XHR/fetch with progress events)
+
+**Cons**: More implementation work (new API route + client-side fetch logic).
+
+## Recommendation
+
+Implement **Option B**. Option A is a stopgap that will run into Vercel
+function constraints at meaningful file sizes and degrades performance.
+The presigned URL pattern is standard for audio/video hosting platforms.
+
+If a fast unblock is needed before Option B is complete, ship Option A
+first as a separate commit, then replace it with Option B.
+
+## Files to Change
+
+### Option A only
+- `app/next.config.ts` — add `serverActions.bodySizeLimit`
+
+### Option B
+- `app/src/app/api/r2/presign/route.ts` — new presign endpoint
+- `app/src/components/simple-upload-form.tsx` — replace form submit with
+  two-phase (presign → direct upload → server action)
+- `app/src/app/podcasts/[id]/episodes/new/page.tsx` — server action now
+  receives R2 key instead of file bytes
+- `app/next.config.ts` — no longer needs a raised limit
+
+## Acceptance Criteria
+
+- [ ] Episodes up to 500 MB upload without error in production
+- [ ] Upload progress is shown to the user (Option B enables this)
+- [ ] Failed R2 upload shows a user-friendly error message
+- [ ] No regression in episode creation flow (DB record created, redirect works)
+- [ ] Existing E2E upload tests pass
+
+## Notes
+
+- The standalone `/episodes/new` page has the same Server Action pattern —
+  check if it shares the same component or needs the same fix applied
+- Vercel Pro plan function body limit is 4.5 MB on hobby, ~250 MB streaming
+  on Pro — Option A may not even work reliably without a plan upgrade
+- R2 presigned URLs use `@aws-sdk/s3-request-presigner` which is already
+  in the R2 library (`app/src/lib/r2.ts`) — check if `getSignedUrl` is
+  already imported/available


### PR DESCRIPTION
## Problem

Episode creation was crashing with:
```
Error: Body exceeded 1 MB limit
```
Next.js Server Actions have a 1 MB default body limit. Every real podcast episode exceeds this.

## Fix

Audio uploads now go **browser → R2 directly** via presigned URLs. The Next.js server is never in the data path.

### New upload flow
```
1. POST /api/r2/presign  →  15-min presigned PUT URL + target audioUrl
2. PUT <presignedUrl>    →  file bytes go direct to R2 (XHR with progress events)
3. POST /api/episodes    →  metadata only (title, description, audioUrl, podcastId)
4. Client redirects to episode list
```

### Changes
| File | Change |
|------|--------|
| `lib/r2.ts` | Add `getPresignedUploadUrl()` via `@aws-sdk/s3-request-presigner` |
| `api/r2/presign/route.ts` | New — auth + podcast ownership + presign |
| `api/episodes/route.ts` | Add POST handler — creates episode from `audioUrl` |
| `components/simple-upload-form.tsx` | Rewrite — 3-phase client upload with progress bar |
| `podcasts/[id]/episodes/new/page.tsx` | Remove Server Action; pass `podcastId` to form |
| `next.config.ts` | Add `serverActions.bodySizeLimit: '10mb'` for other Server Actions |

### Bonus
Users now see a real upload progress bar (0–100%) while the file uploads.

## Test plan
- [ ] Upload a small file (< 1 MB) — works
- [ ] Upload a large file (> 10 MB) — works, no body limit error
- [ ] Upload progress bar increments correctly
- [ ] Validation errors (no title, wrong file type) shown correctly
- [ ] Cancel button works during upload
- [ ] DB record created with correct title, description, audioUrl, podcastId
- [ ] Redirect to episode list on success
- [ ] Unauthenticated presign request returns 401
- [ ] Wrong podcast ID returns 403

🤖 Generated with [Claude Code](https://claude.com/claude-code)