### PR TITLE
fix(tests): resolve E2E TypeScript errors (AMP-46)

### DIFF
--- a/app/e2e/r2.spec.ts
+++ b/app/e2e/r2.spec.ts
@@ -351,7 +351,8 @@ test.describe('R2 File Retrieval and CDN', () => {
     expect(testFileUrl).toBeTruthy();
 
     // Test 1: Verify file retrieval and content integrity
-    const response = await request.get(testFileUrl);
+    // testFileUrl is asserted truthy above; non-null assertion is safe here
+    const response = await request.get(testFileUrl!);
     expect(response.status()).toBe(200);
 
     const retrievedContent = await response.body();
@@ -367,7 +368,7 @@ test.describe('R2 File Retrieval and CDN', () => {
     expect(headers['cache-control']).toBeDefined();
 
     // Test 3: Verify range request support
-    const rangeResponse = await request.get(testFileUrl, {
+    const rangeResponse = await request.get(testFileUrl!, {
       headers: { 'Range': 'bytes=0-99' },
     });
     expect(rangeResponse.status()).toBe(206);
@@ -377,7 +378,7 @@ test.describe('R2 File Retrieval and CDN', () => {
     expect(partialContent.length).toBeGreaterThan(0);
 
     // Test 4: Verify HEAD request support
-    const headResponse = await request.fetch(testFileUrl, { method: 'HEAD' });
+    const headResponse = await request.fetch(testFileUrl!, { method: 'HEAD' });
     expect(headResponse.status()).toBe(200);
     expect((await headResponse.body()).length).toBe(0);
     expect(headResponse.headers()['content-type']).toBeDefined();

--- a/app/e2e/upload.spec.ts
+++ b/app/e2e/upload.spec.ts
@@ -202,7 +202,8 @@ test.describe('Episode Upload', () => {
     });
 
     // Check for file size display
-    const fileSize = page.locator(/\d+\s*(bytes|KB|MB|GB)/).or(
+    // page.locator() only accepts strings; use getByText() for RegExp matching
+    const fileSize = page.getByText(/\d+\s*(bytes|KB|MB|GB)/).or(
       page.locator('[data-testid="file-size"]')
     );
 


### PR DESCRIPTION
## Summary

Fixes 4 pre-existing TypeScript errors that were producing noise on every `tsc --noEmit` run.

| File | Line | Error | Fix |
|------|------|-------|-----|
| `e2e/r2.spec.ts` | 354 | `string \| null` not assignable to `string` | `testFileUrl!` — already asserted truthy above |
| `e2e/r2.spec.ts` | 370 | `string \| null` not assignable to `string` | `testFileUrl!` |
| `e2e/r2.spec.ts` | 380 | `string \| null` not assignable to `string \| Request` | `testFileUrl!` |
| `e2e/upload.spec.ts` | 205 | `RegExp` not assignable to `string` | `page.getByText()` accepts `RegExp`; `page.locator()` does not |

No test logic changed. `npx tsc --noEmit` now exits clean.

## Test plan
- [ ] `npx tsc --noEmit` → zero errors
- [ ] Existing E2E tests unaffected

🤖 Generated with [Claude Code](https://claude.com/claude-code)