### PR TITLE
fix: increase button padding so buttons aren't too small (Vibe Kanban)

### DIFF
--- a/app/src/app/globals.css
+++ b/app/src/app/globals.css
@@ -57,6 +57,7 @@
     align-items: center;
     justify-content: center;
     gap: 0.5rem;
+    padding: 0.625rem 1.25rem;
     border-radius: 0.375rem;
     font-size: 0.875rem;
     font-weight: 500;
@@ -123,8 +124,8 @@
   }
 
   .btn-sm {
-    padding: 0.375rem 0.75rem;
-    font-size: 0.75rem;
+    padding: 0.5rem 1rem;
+    font-size: 0.8125rem;
   }
 
   /* Card styles */


### PR DESCRIPTION
## What

Added default padding to the base `.btn` CSS class and bumped up `.btn-sm` padding/font-size in `globals.css`.

## Why

Buttons across the app were rendering too small, wrapping tightly around their text content with no breathing room. The root cause was that the base `.btn` class had no `padding` defined at all — only `.btn-lg` and `.btn-sm` had explicit padding, leaving the default size effectively zero-padded.

## Changes

- **`.btn`** — added `padding: 0.625rem 1.25rem` (10px vertical / 20px horizontal) as the default button size
- **`.btn-sm`** — increased from `0.375rem 0.75rem` → `0.5rem 1rem` and bumped font-size from `0.75rem` → `0.8125rem` for better readability
- **`.btn-lg`** — left unchanged; was already comfortable at `0.75rem 1.5rem`

All buttons using the `.btn` system (the vast majority of buttons in the app) benefit from this fix automatically.

---

*This PR was written using [Vibe Kanban](https://vibekanban.com)*