### PR TITLE
fix: support all OGG MIME type variants in audio upload validation (Vibe Kanban)

### DIFF
--- a/app/src/lib/r2.ts
+++ b/app/src/lib/r2.ts
@@ -161,6 +161,9 @@ export function isValidAudioFile(file: File): boolean {
     'audio/wave',        // WAV (alternative)
     'audio/x-wav',       // WAV (alternative)
     'audio/ogg',         // OGG
+    'application/ogg',   // OGG (generic container, common browser/OS report)
+    'video/ogg',         // OGG (container MIME, some systems use for audio-only OGG)
+    'audio/x-ogg',       // OGG (alternative)
     'audio/webm',        // WebM Audio
     'audio/flac',        // FLAC
   ];


### PR DESCRIPTION
## What changed

Added three additional OGG MIME type variants to the `isValidAudioFile` validator in `app/src/lib/r2.ts`:

- `application/ogg` — generic OGG container type, commonly reported by Windows browsers
- `video/ogg` — OGG container MIME type used by some Linux systems even for audio-only files
- `audio/x-ogg` — alternative OGG audio MIME type

## Why

Uploading a `.ogg` file to a new episode was failing with "Invalid file type. Please upload an audio file (MP3, M4A, WAV, or OGG)" even though OGG is a supported format.

The root cause: the `isValidAudioFile` function only accepted `audio/ogg`, but browsers and operating systems report the MIME type for `.ogg` files inconsistently:

| Platform | Reported MIME type |
|---|---|
| macOS / Chrome | `audio/ogg` ✅ was passing |
| Windows / Firefox | `application/ogg` ❌ was failing |
| Some Linux | `video/ogg` ❌ was failing |

## Implementation details

Single-file change to `app/src/lib/r2.ts`. The `isValidAudioFile` function is shared by both the server-side upload action (`app/src/app/episodes/new/page.tsx`) and the presign API route (`app/src/app/api/r2/presign/route.ts`), so fixing it in one place covers all upload paths.

---

*This PR was written using [Vibe Kanban](https://vibekanban.com)*