### PR TITLE
feat: delete podcast with cascade episode cleanup (Vibe Kanban)

### DIFF
--- a/app/e2e/podcasts.spec.ts
+++ b/app/e2e/podcasts.spec.ts
@@ -197,7 +197,7 @@ test.describe('Podcast Management', () => {
     expect(isDetailPage || isListPage).toBe(true);
   });
 
-  test('should prevent deleting podcast with episodes', async ({ page }) => {
+  test('should delete a podcast and redirect to podcasts list', async ({ page }) => {
     const testData = generateTestData();
 
     // Create a podcast
@@ -224,7 +224,7 @@ test.describe('Podcast Management', () => {
     await page.click(`text=${testData.title}`);
     await page.waitForURL(/\/podcasts\/[a-f0-9-]+/, { timeout: 5000 });
 
-    // Try to delete the podcast - look for delete button
+    // Look for delete button
     const deleteButton = page.locator('button', { hasText: 'Delete' }).or(
       page.locator('button', { hasText: /delete/i })
     );
@@ -232,22 +232,16 @@ test.describe('Podcast Management', () => {
     const deleteCount = await deleteButton.count();
 
     if (deleteCount > 0) {
-      // Delete button exists - try to click it
       await deleteButton.first().click();
 
-      // Check for confirmation dialog or error message
-      await page.waitForTimeout(1000);
+      // Wait for redirect to podcasts list after deletion
+      await page.waitForTimeout(2000);
 
-      // Either we got a confirmation dialog, or an error, or nothing happened
-      // All are acceptable outcomes - we just want to verify the delete flow exists
+      // Should navigate to podcasts list
       const finalUrl = page.url();
-      const isStillOnDetailPage = finalUrl.match(/\/podcasts\/[a-f0-9-]+/);
-
-      // If still on detail page, either got dialog or was prevented
-      // If navigated away, deletion succeeded (also OK for test)
-      expect(isStillOnDetailPage || finalUrl.includes('/podcasts')).toBe(true);
+      expect(finalUrl).toContain('/podcasts');
     } else {
-      // No delete button - might not be implemented yet, that's OK
+      // No delete button found - not yet implemented, pass
       expect(true).toBe(true);
     }
   });

--- a/app/src/app/api/podcasts/[id]/route.ts
+++ b/app/src/app/api/podcasts/[id]/route.ts
@@ -1,5 +1,6 @@
 import { NextRequest, NextResponse } from 'next/server';
 import { createClient } from '@/lib/supabase/server';
+import { deleteFromR2, getR2EpisodesCustomDomain } from '@/lib/r2';
 
 export async function GET(
   request: NextRequest,
@@ -123,24 +124,44 @@ export async function DELETE(
     }
 
     const { id } = await params;
-    const { data: episodes, error: checkError } = await supabase
-      .from('episodes')
-      .select('id')
-      .eq('podcast_id', id)
-      .limit(1);
 
-    if (checkError) {
-      console.error('Error checking episodes:', checkError);
-      return NextResponse.json({ error: 'Failed to check podcast episodes' }, { status: 500 });
+    // Verify the podcast belongs to the user before doing anything
+    const { data: podcast, error: podcastError } = await supabase
+      .from('podcasts')
+      .select('id')
+      .eq('id', id)
+      .eq('user_id', user.id)
+      .single();
+
+    if (podcastError || !podcast) {
+      return NextResponse.json({ error: 'Podcast not found' }, { status: 404 });
     }
 
+    // Fetch all episodes so we can clean up R2 files
+    const { data: episodes, error: episodesError } = await supabase
+      .from('episodes')
+      .select('id, audio_url')
+      .eq('podcast_id', id);
+
+    if (episodesError) {
+      console.error('Error fetching episodes for podcast:', episodesError);
+      return NextResponse.json({ error: 'Failed to fetch podcast episodes' }, { status: 500 });
+    }
+
+    // Delete R2 audio files for all episodes (best-effort, non-blocking)
     if (episodes && episodes.length > 0) {
-      return NextResponse.json(
-        { error: 'Cannot delete podcast with episodes. Delete episodes first.' },
-        { status: 400 }
+      const r2CustomDomain = getR2EpisodesCustomDomain();
+      await Promise.allSettled(
+        episodes
+          .filter((ep) => ep.audio_url && r2CustomDomain && ep.audio_url.startsWith(r2CustomDomain))
+          .map((ep) => {
+            const key = ep.audio_url.replace(r2CustomDomain!, '').replace(/^\//, '');
+            return deleteFromR2(key);
+          })
       );
     }
 
+    // Deleting the podcast cascades to episodes in the DB (ON DELETE CASCADE)
     const { error } = await supabase
       .from('podcasts')
       .delete()


### PR DESCRIPTION
## What Changed

Previously, deleting a podcast was blocked if it had any episodes — the API returned a `400` error with "Cannot delete podcast with episodes. Delete episodes first."

This PR changes that behaviour so deleting a podcast cascades cleanly:

1. **Verifies ownership** — confirms the podcast belongs to the authenticated user before proceeding.
2. **Cleans up R2 audio files** — fetches all associated episodes and deletes their audio files from Cloudflare R2 (best-effort via `Promise.allSettled`, so a missing file won't block the operation).
3. **Cascades the DB delete** — the podcast row is deleted; the `ON DELETE CASCADE` foreign key on `episodes.podcast_id` removes all episode rows automatically.

## Implementation Details

- `deleteFromR2` / `getR2EpisodesCustomDomain` helpers are imported from `@/lib/r2` and used to resolve the R2 object key from each episode's `audio_url`.
- R2 deletion is wrapped in `Promise.allSettled` so individual file-not-found errors don't abort the whole request.
- Only audio URLs that start with the configured R2 custom domain are sent to R2 for deletion (guards against temp:// or external URLs).

## E2E Test Update

The existing test "should prevent deleting podcast with episodes" was updated to reflect the new expected behaviour: after clicking Delete the user should be redirected to `/podcasts`, not blocked with an error.

---

*This PR was written using [Vibe Kanban](https://vibekanban.com)*