### PR TITLE
fix(rss): add public RLS policies for anon RSS feed access (Vibe Kanban)

### DIFF
--- a/app/supabase/migrations/20260328000000_public_rss_read_policies.sql
+++ b/app/supabase/migrations/20260328000000_public_rss_read_policies.sql
@@ -1,0 +1,14 @@
+-- Allow public (anon) read access to podcasts and episodes for RSS feed generation.
+-- The RSS route uses the anon Supabase client (no auth) so RLS must permit anon SELECT.
+
+-- Podcasts: allow public SELECT (RSS feed looks up podcasts by rss_slug without auth)
+CREATE POLICY "Public can view podcasts"
+  ON podcasts FOR SELECT
+  TO anon
+  USING (true);
+
+-- Episodes: allow public SELECT for episodes belonging to any podcast (RSS feed content)
+CREATE POLICY "Public can view podcast episodes"
+  ON episodes FOR SELECT
+  TO anon
+  USING (podcast_id IS NOT NULL);


### PR DESCRIPTION
## What changed

Added a new Supabase migration (`20260328000000_public_rss_read_policies.sql`) that creates two RLS policies granting `anon` (unauthenticated) read access to the `podcasts` and `episodes` tables.

## Why

The podcast RSS feed endpoint (`/rss/[slug]`) uses a public Supabase client initialized with the anon key — no user session or auth token is involved. However, all existing RLS policies on `podcasts` and `episodes` were scoped to `TO authenticated`, meaning the anon role had zero read access.

When a podcast player or directory fetched a feed URL (e.g. `https://www.automapod.app/rss/my-test-podcast-1`), the Supabase query returned 0 rows due to RLS blocking the anon client, causing the route to return `{"error": "Podcast not found"}`.

## Implementation details

- `Public can view podcasts` — grants `anon` SELECT on `podcasts` with `USING (true)`. All podcasts are public feeds by design.
- `Public can view podcast episodes` — grants `anon` SELECT on `episodes` with `USING (podcast_id IS NOT NULL)`. Since `podcast_id` has a NOT NULL constraint (enforced in migration `20260318000000`), this is effectively `true` but makes the intent explicit.
- No INSERT/UPDATE/DELETE access is granted — strictly read-only.
- Existing authenticated policies are unaffected.

---

*This PR was written using [Vibe Kanban](https://vibekanban.com)*