### PR TITLE
fix(ci): add Bun setup for E2E tests

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -48,6 +48,11 @@ jobs:
       - name: Install dependencies
         run: npm ci
 
+      - name: Setup Bun
+        uses: oven-sh/setup-bun@v2
+        with:
+          bun-version: latest
+
       - name: Install Playwright browsers
         run: npx playwright install --with-deps
 


### PR DESCRIPTION
Add Bun setup step before running E2E tests to ensure bun is available for the test environment. This fixes failing tests due to missing bun requirement.